### PR TITLE
Build the path to the fixture directory from the config file path

### DIFF
--- a/pytest_mongodb/plugin.py
+++ b/pytest_mongodb/plugin.py
@@ -82,9 +82,9 @@ def clean_database(db):
 
 
 def load_fixtures(db, config):
-    config_dir = config.inifile.join('..')
     fixture_dir = config.getoption('mongodb_fixture_dir') or config.getini('mongodb_fixture_dir')
-    basedir = str(config_dir.join(fixture_dir))
+    if not os.path.isabs(fixture_dir):
+        basedir = str(config.inifile.join('..', fixture_dir))
     fixtures = config.getini('mongodb_fixtures')
 
     for file_name in os.listdir(basedir):

--- a/pytest_mongodb/plugin.py
+++ b/pytest_mongodb/plugin.py
@@ -82,7 +82,9 @@ def clean_database(db):
 
 
 def load_fixtures(db, config):
-    basedir = config.getoption('mongodb_fixture_dir') or config.getini('mongodb_fixture_dir')
+    config_dir = config.inifile.join('..')
+    fixture_dir = config.getoption('mongodb_fixture_dir') or config.getini('mongodb_fixture_dir')
+    basedir = str(config_dir.join(fixture_dir))
     fixtures = config.getini('mongodb_fixtures')
 
     for file_name in os.listdir(basedir):

--- a/pytest_mongodb/plugin.py
+++ b/pytest_mongodb/plugin.py
@@ -82,9 +82,9 @@ def clean_database(db):
 
 
 def load_fixtures(db, config):
-    fixture_dir = config.getoption('mongodb_fixture_dir') or config.getini('mongodb_fixture_dir')
-    if not os.path.isabs(fixture_dir):
-        basedir = str(config.inifile.join('..', fixture_dir))
+    basedir = config.getoption('mongodb_fixture_dir') or config.getini('mongodb_fixture_dir')
+    if not os.path.isabs(basedir):
+        basedir = config.rootdir.join(basedir).strpath
     fixtures = config.getini('mongodb_fixtures')
 
     for file_name in os.listdir(basedir):


### PR DESCRIPTION
Current behaviour:
with the following project architecture:
```
project
    | mongo_db_mock_folder
        | reference_results.json
    | package
           | tests
                | test_1.py
                | test_2.py
    | pytest.ini
```
and pytest.ini:
```
[pytest]
mongodb_fixture_dir = ./mongo_db_mock_folder/
mongodb_fixtures = reference_results
```
from an IDE, if the tests are launched from the project, they pass. If the tests are launched from the tests folder, they failed because of a raised `FileNotFoundError`.

This pull request build the relative path from the config file not the launch path. Tests can be launched from every folder without raising a `FileNotFoundError`.