### PR TITLE
Add info on how to configure a custom mongod executable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,8 @@ settings to your needs:
     mongodb_dbname = mydbname
 
 
+For Mac users, who installed mongodb using homebrew, you can configure the executable to be picked up from `/usr/local/bin/mongod` instead of `/usr/local/bin/mongod` by using `mongo_exec = /usr/local/bin/mongod` in the `pytest.ini` file.
+
 Basic usage
 -----------
 


### PR DESCRIPTION
In Mac the process fails because the executable `mongod` is not found. 

Usual installation of mongodb via homebrew would isntall mongod under `/usr/local/bin/mongod`