### PR TITLE
fix: do not fail plugin loading if optional dependency pymongo is missing

### DIFF
--- a/pytest_mongodb/plugin.py
+++ b/pytest_mongodb/plugin.py
@@ -6,8 +6,14 @@ import codecs
 from bson import json_util
 import mongomock
 import pytest
-import pymongo
 import yaml
+
+try:
+    import pymongo
+
+    HAVE_PYMONGO = True
+except ImportError:
+    HAVE_PYMONGO = False
 
 
 _cache = {}
@@ -76,6 +82,8 @@ def make_mongo_client(config):
     engine = config.getoption('mongodb_engine') or config.getini('mongodb_engine')
     host = config.getoption('mongodb_host') or config.getini('mongodb_host')
     if engine == 'pymongo':
+        if not HAVE_PYMONGO:
+            pytest.fail("PyMongo is not installed.")
         client = pymongo.MongoClient(host)
     else:
         client = mongomock.MongoClient(host)


### PR DESCRIPTION
pymongo is not an explicit dependency of pytest-mongodb, and as long as you do not change the engine, pytest-mongodb should just work fine without it.

Instead of crashing the plugin loading, this PR only fails tests if pymongo is not installed *and* the engine has been changed to pymongo.